### PR TITLE
Switch add-lore command to single-quotes

### DIFF
--- a/lorebot.js
+++ b/lorebot.js
@@ -111,11 +111,11 @@ function trunksifyLore(data){
 		return;
 
 	var trunksifiedLore = "";
-	lore.text = lore.text.replace(/"/g, "'");
+	lore.text = lore.text.replace(/'/g, "\\'");
 	//LOL Javascript. Actually I think the add-lore does this automatically.
 	var loreDate = new Date(lore.timestamp.split(".")[0] * 1000);
 
-	trunksifiedLore += "$ add-lore \"[{0}]: {1} \"";
+	trunksifiedLore += "$ add-lore '[{0}]: {1}'";
 	//TODO: make it so time is given in a less dumb way.
 	trunksifiedLore = trunksifiedLore.format(userData.user.name, lore.text);
 


### PR DESCRIPTION
This switches lorebot to pass lore to add-lore in single quotes (which don't cause bash to try to expand variables). It also uses literal `\'` as the replacement for single-quotes in the lore, so they are escaped by bash.

Fixes #1 
