### PR TITLE
Use loredb

### DIFF
--- a/lorebot.js
+++ b/lorebot.js
@@ -115,7 +115,7 @@ function trunksifyLore(data){
 	//LOL Javascript. Actually I think the add-lore does this automatically.
 	var loreDate = new Date(lore.timestamp.split(".")[0] * 1000);
 
-	trunksifiedLore += "$ add-lore \"[{0}]: {1} \"";
+	trunksifiedLore += "$ loredb add \"{0}\" \"{1}\"";
 	//TODO: make it so time is given in a less dumb way.
 	trunksifiedLore = trunksifiedLore.format(userData.user.name, lore.text);
 


### PR DESCRIPTION
This switches lorebot to call `loredb` directly instead of using `add-lore.py`.

(This will let us get rid of the old `add-lore.py` and switch everyone over to using loredb directly.)
